### PR TITLE
Fix/illegal expression attr values

### DIFF
--- a/src/condition.test.ts
+++ b/src/condition.test.ts
@@ -127,4 +127,27 @@ describe(`condition expression`, () => {
     };
     expect(result).toStrictEqual(expected);
   });
+  
+  it(`builds the ConditionExpression and NameValueMaps - avoid erroring values map`, () => {
+    expect.assertions(1);
+    const Condition = {
+      a: `attribute_exists`,
+      b: `attribute_not_exists`
+    };
+    const params: ConditionInput = { Condition };
+    const result = getConditionExpression(params);
+    const expected = {
+      ConditionExpression: [
+        `attribute_exists(#n2661)`,
+        `attribute_not_exists(#n578f)`
+      ]
+        .map((exp) => `(${exp})`)
+        .join(` AND `),
+      ExpressionAttributeNames: {
+        '#n2661': `a`,
+        '#n578f': `b`
+      }
+    };
+    expect(result).toStrictEqual(expected);
+  });
 });

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -25,7 +25,7 @@ export const getConditionExpression: GetConditionExpressionFn = (
 ) => {
   if (!params.Condition) return params;
   const { Condition, ConditionLogicalOperator, ...restOfParams } = params;
-  return {
+  const paramsWithConditions = {
     ...restOfParams,
     ConditionExpression: buildConditionExpression({
       Condition,
@@ -34,4 +34,7 @@ export const getConditionExpression: GetConditionExpressionFn = (
     ExpressionAttributeNames: buildConditionAttributeNames(Condition, params),
     ExpressionAttributeValues: buildConditionAttributeValues(Condition, params),
   };
+  
+  if(Object.keys(paramsWithConditions.ExpressionAttributeValues).length === 0) delete paramsWithConditions.ExpressionAttributeValues;
+  return paramsWithConditions;
 };


### PR DESCRIPTION
### Changes
---
- Updated `condition.ts` to remove the ExpressionAttributeValues attribute from the params when no values were present. DynamoDB will throw an error if that attribute is set to an empty object. 
- Added test case to `condition.test.ts` where an operation defining only conditions using `attribute_not_exists` and `attribute_exists` will result in a param set that excludes an empty `ExpressionAttributeValues` object.

See issue #1 for more details about this.