### PR TITLE
feat: multiple update operations in one expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,11 @@ type DynamoDbValue =
 
   Update: { [key: string]: DynamoDbValue },
   UpdateAction: 'SET' | 'ADD' | 'DELETE' | 'REMOVE';
+
+  UpdateSet: { [key: string]: DynamoDbValue },
+  UpdateAdd: { [key: string]: DynamoDbValue },
+  UpdateDelete: { [key: string]: DynamoDbValue },
+  UpdateRemove: { [key: string]: DynamoDbValue },
 }
 ```
 

--- a/src/@types/dynoexpr.d.ts
+++ b/src/@types/dynoexpr.d.ts
@@ -107,8 +107,12 @@ declare module 'dynoexpr' {
   export type Update = Record<string, DynamoDbValue>;
   export type UpdateAction = 'SET' | 'ADD' | 'DELETE' | 'REMOVE';
   export type UpdateInput = Partial<{
-    Update: Update;
-    UpdateAction: UpdateAction;
+    Update?: Update;
+    UpdateAction?: UpdateAction;
+    UpdateRemove?: Update;
+    UpdateAdd?: Update;
+    UpdateSet?: Update;
+    UpdateDelete?: Update;
     ExpressionAttributeNames: { [key: string]: string };
     ExpressionAttributeValues: { [key: string]: DynamoDbValue };
   }>;

--- a/src/expressions/update-ops.test.ts
+++ b/src/expressions/update-ops.test.ts
@@ -1,0 +1,127 @@
+import type { UpdateInput } from 'dynoexpr';
+import {
+  getUpdateSetExpression,
+  getUpdateRemoveExpression,
+  getUpdateAddExpression,
+  getUpdateDeleteExpression,
+  getUpdateOperationsExpression,
+} from './update-ops';
+
+describe('update operations - SET/REMOVE/ADD/DELETE', () => {
+  it('builds a SET update expression', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateSet: {
+        foo: 'foo - 2',
+        bar: '2 - bar',
+        baz: 'baz + 9',
+      },
+    };
+    const result = getUpdateSetExpression(params);
+    const expected = {
+      UpdateExpression:
+        'SET #na4d8 = #na4d8 - :v862c, #n51f2 = :v862c - #n51f2, #n6e88 = #n6e88 + :vad26',
+      ExpressionAttributeNames: {
+        '#na4d8': 'foo',
+        '#n51f2': 'bar',
+        '#n6e88': 'baz',
+      },
+      ExpressionAttributeValues: {
+        ':v862c': 2,
+        ':vad26': 9,
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('builds a REMOVE update expression', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateRemove: {
+        foo: 'bar',
+        baz: 2,
+      },
+    };
+    const result = getUpdateRemoveExpression(params);
+    const expected = {
+      UpdateExpression: 'REMOVE #na4d8, #n6e88',
+      ExpressionAttributeNames: {
+        '#na4d8': 'foo',
+        '#n6e88': 'baz',
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('builds an ADD update expression', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateAdd: {
+        foo: 'bar',
+        baz: 2,
+      },
+    };
+    const result = getUpdateAddExpression(params);
+    const expected = {
+      UpdateExpression: 'ADD #na4d8 :v51f2, #n6e88 :v862c',
+      ExpressionAttributeNames: {
+        '#na4d8': 'foo',
+        '#n6e88': 'baz',
+      },
+      ExpressionAttributeValues: {
+        ':v51f2': 'bar',
+        ':v862c': 2,
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('builds a DELETE update expression', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateDelete: {
+        foo: 'bar',
+        baz: 2,
+      },
+    };
+    const result = getUpdateDeleteExpression(params);
+    const expected = {
+      UpdateExpression: 'DELETE #na4d8 :v51f2, #n6e88 :v862c',
+      ExpressionAttributeNames: {
+        '#na4d8': 'foo',
+        '#n6e88': 'baz',
+      },
+      ExpressionAttributeValues: {
+        ':v51f2': 'bar',
+        ':v862c': 2,
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('builds multiple update expressions', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateSet: { ufoo: 'ufoo - 2' },
+      UpdateRemove: { rfoo: 'rbar' },
+      UpdateAdd: { afoo: 'abar' },
+      UpdateDelete: { dfoo: 'dbar' },
+    };
+    const result = getUpdateOperationsExpression(params);
+    const expected = {
+      UpdateExpression:
+        'SET #nff12 = #nff12 - :v862c REMOVE #nff12, #n978b ADD #nb01c :ve948 DELETE #nd358 :v45cc',
+      ExpressionAttributeNames: {
+        '#n978b': 'rfoo',
+        '#nb01c': 'afoo',
+        '#nd358': 'dfoo',
+        '#nff12': 'ufoo',
+      },
+      ExpressionAttributeValues: {
+        ':v45cc': 'dbar',
+        ':ve948': 'abar',
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/src/expressions/update-ops.test.ts
+++ b/src/expressions/update-ops.test.ts
@@ -49,6 +49,10 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         '#na4d8': 'foo',
         '#n6e88': 'baz',
       },
+      ExpressionAttributeValues: {
+        ':v51f2': 'bar',
+        ':v862c': 2,
+      },
     };
     expect(result).toStrictEqual(expected);
   });
@@ -118,7 +122,9 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         '#nff12': 'ufoo',
       },
       ExpressionAttributeValues: {
+        ':v0e91': 'rbar',
         ':v45cc': 'dbar',
+        ':v862c': 2,
         ':ve948': 'abar',
       },
     };

--- a/src/expressions/update-ops.ts
+++ b/src/expressions/update-ops.ts
@@ -59,7 +59,13 @@ export const getUpdateOperationsExpression: GetUpdateExpressionFn = (
     return expr;
   }, params as UpdateOutput);
 
-  outputParams.UpdateExpression = updateExpressions.filter(Boolean).join(' ');
+  const aggUpdateExpression = updateExpressions
+    .filter(Boolean)
+    .filter((e, i, a) => a.indexOf(e) === i)
+    .join(' ');
+  if (aggUpdateExpression) {
+    outputParams.UpdateExpression = aggUpdateExpression;
+  }
 
   return outputParams;
 };

--- a/src/expressions/update-ops.ts
+++ b/src/expressions/update-ops.ts
@@ -1,0 +1,65 @@
+import type { UpdateInput, UpdateOutput } from 'dynoexpr';
+import { getUpdateExpression } from './update';
+
+type GetUpdateExpressionFn = (params?: UpdateInput) => UpdateOutput;
+
+export const getUpdateSetExpression: GetUpdateExpressionFn = (params = {}) => {
+  const { UpdateSet, ...restOfParams } = params;
+  return getUpdateExpression({
+    ...restOfParams,
+    Update: UpdateSet,
+    UpdateAction: 'SET',
+  });
+};
+
+export const getUpdateRemoveExpression: GetUpdateExpressionFn = (
+  params = {}
+) => {
+  const { UpdateRemove, ...restOfParams } = params;
+  return getUpdateExpression({
+    ...restOfParams,
+    Update: UpdateRemove,
+    UpdateAction: 'REMOVE',
+  });
+};
+
+export const getUpdateAddExpression: GetUpdateExpressionFn = (params = {}) => {
+  const { UpdateAdd, ...restOfParams } = params;
+  return getUpdateExpression({
+    ...restOfParams,
+    Update: UpdateAdd,
+    UpdateAction: 'ADD',
+  });
+};
+
+export const getUpdateDeleteExpression: GetUpdateExpressionFn = (
+  params = {}
+) => {
+  const { UpdateDelete, ...restOfParams } = params;
+  return getUpdateExpression({
+    ...restOfParams,
+    Update: UpdateDelete,
+    UpdateAction: 'DELETE',
+  });
+};
+
+export const getUpdateOperationsExpression: GetUpdateExpressionFn = (
+  params = {}
+) => {
+  const updateExpressions: string[] = [];
+  const outputParams = [
+    getUpdateSetExpression,
+    getUpdateRemoveExpression,
+    getUpdateAddExpression,
+    getUpdateDeleteExpression,
+  ].reduce((acc, getExpressionFn) => {
+    const expr = getExpressionFn(acc);
+    const { UpdateExpression = '' } = expr;
+    updateExpressions.push(UpdateExpression);
+    return expr;
+  }, params as UpdateOutput);
+
+  outputParams.UpdateExpression = updateExpressions.filter(Boolean).join(' ');
+
+  return outputParams;
+};

--- a/src/expressions/update.test.ts
+++ b/src/expressions/update.test.ts
@@ -167,26 +167,6 @@ describe('update expression', () => {
     expect(result).toStrictEqual(expected);
   });
 
-  it('removes attributes - REMOVE', () => {
-    expect.assertions(1);
-    const params: UpdateInput = {
-      Update: {
-        foo: 'bar',
-        baz: 2,
-      },
-      UpdateAction: 'REMOVE',
-    };
-    const result = getUpdateExpression(params);
-    const expected = {
-      UpdateExpression: 'REMOVE #na4d8, #n6e88',
-      ExpressionAttributeNames: {
-        '#na4d8': 'foo',
-        '#n6e88': 'baz',
-      },
-    };
-    expect(result).toStrictEqual(expected);
-  });
-
   it('updates numeric values or sets - ADD', () => {
     expect.assertions(1);
     const params: UpdateInput = {

--- a/src/expressions/update.ts
+++ b/src/expressions/update.ts
@@ -84,9 +84,5 @@ export const getUpdateExpression: GetUpdateExpressionFn = (params = {}) => {
     ExpressionAttributeValues,
   };
 
-  if (UpdateAction === 'REMOVE') {
-    delete parameters.ExpressionAttributeValues;
-  }
-
   return parameters;
 };

--- a/src/operations/single.ts
+++ b/src/operations/single.ts
@@ -3,16 +3,46 @@ import { getConditionExpression } from '../expressions/condition';
 import { getFilterExpression } from '../expressions/filter';
 import { getProjectionExpression } from '../expressions/projection';
 import { getUpdateExpression } from '../expressions/update';
+import { getUpdateOperationsExpression } from '../expressions/update-ops';
 import { getKeyConditionExpression } from '../expressions/key-condition';
+
+type IsUpdateRemoveOnlyPresentFn = (params: DynoexprInput) => boolean;
+export const isUpdateRemoveOnlyPresent: IsUpdateRemoveOnlyPresentFn = (
+  params
+) => {
+  const { UpdateAction, UpdateRemove } = params;
+  if (UpdateAction !== 'REMOVE' && typeof UpdateRemove === 'undefined')
+    return false;
+
+  const { Condition, Filter, KeyCondition } = params;
+  const otherPresent = [Condition, Filter, KeyCondition].some(
+    (key) => typeof key !== 'undefined'
+  );
+  if (otherPresent) {
+    return false;
+  }
+
+  return true;
+};
 
 export function getSingleTableExpressions<
   T extends DynoexprOutput = DynoexprOutput
 >(params: DynoexprInput = {}): T {
-  return [
+  const expression = [
     getKeyConditionExpression,
     getConditionExpression,
     getFilterExpression,
     getProjectionExpression,
     getUpdateExpression,
+    getUpdateOperationsExpression,
   ].reduce((acc, getExpressionFn) => getExpressionFn(acc), params) as T;
+
+  delete expression.Update;
+  delete expression.UpdateAction;
+
+  if (isUpdateRemoveOnlyPresent(params)) {
+    delete expression.ExpressionAttributeValues;
+  }
+
+  return expression;
 }


### PR DESCRIPTION
Handle multiple update operations in one expression.

Given: 
```
{
  UpdateSet: { ufoo: 'ufoo - 2' },
  UpdateRemove: { rfoo: 'rbar' },
  UpdateAdd: { afoo: 'abar' },
  UpdateDelete: { dfoo: 'dbar' },
}
```

produces this DDB expression:
```
{
  UpdateExpression:
    'SET #nff12 = #nff12 - :v862c REMOVE #nff12, #n978b ADD #nb01c :ve948 DELETE #nd358 :v45cc',
  ExpressionAttributeNames: {
    '#n978b': 'rfoo',
    '#nb01c': 'afoo',
    '#nd358': 'dfoo',
    '#nff12': 'ufoo',
  },
  ExpressionAttributeValues: {
    ':v0e91': 'rbar',
    ':v45cc': 'dbar',
    ':v862c': 2,
    ':ve948': 'abar',
  },
}
```