### PR TITLE
feat: convert Set values to DynamoDbSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,52 @@ const params = dynoexpr({
 */
 ```
 
+**Working with Sets**
+
+If a value is provided as a Set, it will be converted to `DocumentClient.DynamoDbSet`.
+
+```typescript
+const params = dynoexpr({
+  Update: {
+    Color: new Set(['Orange', 'Purple']);
+  }
+})
+
+/*
+{
+  UpdateExpression: 'SET #n7295 = :v0a80',
+  ExpressionAttributeNames: {
+    '#n7295': 'Color',
+  },
+  ExpressionAttributeValues: {
+    ':v0a80': docClient.createSet(['Orange', 'Purple']),
+  },
+}
+*/
+```
+
+**When using UpdateAdd or UpdateDelete, arrays are converted to DynamoDbSet**
+
+```typescript
+const params = dynoexpr({
+  UpdateAdd: {
+    Color: ['Orange', 'Purple'];
+  }
+})
+
+/*
+{
+  UpdateExpression: 'ADD #n7295 :v0a80',
+  ExpressionAttributeNames: {
+    '#n7295': 'Color',
+  },
+  ExpressionAttributeValues: {
+    ':v0a80': docClient.createSet(['Orange', 'Purple']),
+  },
+}
+*/
+```
+
 **Keep existing Expressions, AttributeNames and AttributeValues**
 
 ```typescript
@@ -298,7 +344,7 @@ type DynamoDbValue =
   Projection: string[],
 
   Update: { [key: string]: DynamoDbValue },
-  UpdateAction: 'SET' | 'ADD' | 'DELETE' | 'REMOVE';
+  UpdateAction: 'SET' | 'ADD' | 'DELETE' | 'REMOVE',
 
   UpdateSet: { [key: string]: DynamoDbValue },
   UpdateAdd: { [key: string]: DynamoDbValue },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "module": "lib/index.modern.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
+  "peerDependencies": {
+    "aws-sdk": "^2.2.0"
+  },
   "devDependencies": {
     "@types/jest": "26.0.14",
     "@types/node": "14.11.1",

--- a/src/@types/dynoexpr.d.ts
+++ b/src/@types/dynoexpr.d.ts
@@ -10,7 +10,8 @@ declare module 'dynoexpr' {
   export type DynamoDbValue =
     | DynamoDbPrimitive
     | DynamoDbPrimitive[]
-    | Set<DynamoDbPrimitive>;
+    | Set<DynamoDbPrimitive>
+    | unknown;
 
   // batch operations
   export type BatchGetInput = ProjectionInput & Record<string, unknown>;

--- a/src/expressions/update.test.ts
+++ b/src/expressions/update.test.ts
@@ -167,49 +167,70 @@ describe('update expression', () => {
     expect(result).toStrictEqual(expected);
   });
 
-  it('updates numeric values or sets - ADD', () => {
+  it('adds a number - ADD', () => {
     expect.assertions(1);
     const params: UpdateInput = {
-      Update: {
-        foo: 'bar',
-        baz: 2,
-      },
       UpdateAction: 'ADD',
+      Update: {
+        foo: 5,
+      },
     };
     const result = getUpdateExpression(params);
     const expected = {
-      UpdateExpression: 'ADD #na4d8 :v51f2, #n6e88 :v862c',
+      UpdateExpression: 'ADD #na4d8 :v18d5',
       ExpressionAttributeNames: {
         '#na4d8': 'foo',
-        '#n6e88': 'baz',
       },
       ExpressionAttributeValues: {
-        ':v51f2': 'bar',
-        ':v862c': 2,
+        ':v18d5': 5,
       },
     };
     expect(result).toStrictEqual(expected);
   });
 
-  it('deletes items from sets - DELETE', () => {
+  it('adds elements to a set - SET', () => {
     expect.assertions(1);
     const params: UpdateInput = {
+      UpdateAction: 'ADD',
       Update: {
-        foo: 'bar',
-        baz: 2,
+        foo: [1, 2],
+        bar: ['bar', 'baz'],
       },
-      UpdateAction: 'DELETE',
     };
     const result = getUpdateExpression(params);
     const expected = {
-      UpdateExpression: 'DELETE #na4d8 :v51f2, #n6e88 :v862c',
+      UpdateExpression: 'ADD #na4d8 :vd26b, #n51f2 :v9ad1',
       ExpressionAttributeNames: {
+        '#n51f2': 'bar',
         '#na4d8': 'foo',
-        '#n6e88': 'baz',
       },
       ExpressionAttributeValues: {
-        ':v51f2': 'bar',
-        ':v862c': 2,
+        ':v649c': new Set(['bar', 'baz']),
+        ':veb45': new Set([1, 2]),
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('removes element from a set - DELETE', () => {
+    expect.assertions(1);
+    const params: UpdateInput = {
+      UpdateAction: 'DELETE',
+      Update: {
+        foo: [1, 2],
+        bar: ['bar', 'baz'],
+      },
+    };
+    const result = getUpdateExpression(params);
+    const expected = {
+      UpdateExpression: 'DELETE #na4d8 :vd26b, #n51f2 :v9ad1',
+      ExpressionAttributeNames: {
+        '#n51f2': 'bar',
+        '#na4d8': 'foo',
+      },
+      ExpressionAttributeValues: {
+        ':v649c': new Set(['bar', 'baz']),
+        ':veb45': new Set([1, 2]),
       },
     };
     expect(result).toStrictEqual(expected);

--- a/src/expressions/update.ts
+++ b/src/expressions/update.ts
@@ -28,7 +28,9 @@ export const getExpressionAttributes: GetExpressionAttributesFn = (params) => {
     const v = isMathExpression(key, value)
       ? parseOperationValue(value as string, key)
       : value;
-    acc.ExpressionAttributeValues[getAttrValue(v)] = v;
+    acc.ExpressionAttributeValues[getAttrValue(v)] = Array.isArray(v)
+      ? new Set(v)
+      : v;
     return acc;
   }, params as ExpressionAttributesMap);
 };
@@ -66,8 +68,15 @@ export const getUpdateExpression: GetUpdateExpressionFn = (params = {}) => {
     case 'ADD':
     case 'DELETE':
       entries = Object.entries(Update)
+        .map(
+          ([name, value]) =>
+            [name, Array.isArray(value) ? new Set(value) : value] as [
+              string,
+              unknown
+            ]
+        )
         .map(([name, value]) => [getAttrName(name), getAttrValue(value)])
-        .map(([name, value]) => `${name} ${value}`)
+        .map(([exprName, exprValue]) => `${exprName} ${exprValue}`)
         .join(', ');
       break;
     case 'REMOVE':

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,59 +1,49 @@
 import { toString, md5, getAttrName, getAttrValue } from './utils';
 
 describe('expression helpers', () => {
-  it('converts to string', () => {
-    expect.assertions(7);
-    const values = ['foo', 2, false, null, undefined, { foo: 'bar' }, ['foo']];
-    const expected = [
-      'foo',
-      '2',
-      'false',
-      'null',
-      'undefined',
-      '{"foo":"bar"}',
-      '["foo"]',
-    ];
-    values.forEach((value, i) => {
-      const result = toString(value);
-      expect(result).toBe(expected[i]);
-    });
+  it.each([
+    ['string', 'foo', 'foo'],
+    ['number', 2, '2'],
+    ['boolean', false, 'false'],
+    ['null', null, 'null'],
+    ['undefined', undefined, 'undefined'],
+    ['object', { foo: 'bar' }, '{"foo":"bar"}'],
+    ['array', ['foo', 'bar'], '["foo","bar"]'],
+    ['set of numbers', new Set([1, 2]), 'Set([1,2]))'],
+    ['set of strings', new Set(['foo', 'bar']), 'Set(["foo","bar"]))'],
+  ])('converts to string - %s', (_, value, expected) => {
+    const result = toString(value);
+    expect(result).toBe(expected);
   });
 
-  it('hashes any value', () => {
-    expect.assertions(7);
-    const values = ['foo', 2, false, null, undefined, { foo: 'bar' }, ['foo']];
-    const expected = [
-      'acbd18db4cc2f85cedef654fccc4a4d8',
-      'c81e728d9d4c2f636f067f89cc14862c',
-      '68934a3e9455fa72420237eb05902327',
-      '37a6259cc0c1dae299a7866489dff0bd',
-      '5e543256c480ac577d30f76f9120eb74',
-      '9bb58f26192e4ba00f01e2e7b136bbd8',
-      'a0cc55529e8a5748afb69ba8ebeebad8',
-    ];
-    values.forEach((value, i) => {
-      const result = md5(value);
-      expect(result).toBe(expected[i]);
-    });
+  it.each([
+    ['string', 'foo', 'acbd18db4cc2f85cedef654fccc4a4d8'],
+    ['number', 2, 'c81e728d9d4c2f636f067f89cc14862c'],
+    ['boolean', false, '68934a3e9455fa72420237eb05902327'],
+    ['null', null, '37a6259cc0c1dae299a7866489dff0bd'],
+    ['undefined', undefined, '5e543256c480ac577d30f76f9120eb74'],
+    ['object', { foo: 'bar' }, '9bb58f26192e4ba00f01e2e7b136bbd8'],
+    ['array', ['foo', 'bar'], '1ea13cb52ddd7c90e9f428d1df115d8f'],
+    ['set of numbers', new Set([1, 2]), '8c627cc9d533e8fa591e2687101cd26b'],
+    ['set of strings', new Set(['foo']), 'a4c6dd1467761291b805998fe24e60df'],
+  ])('hashes any value - %s', (_, value, expected) => {
+    const result = md5(value);
+    expect(result).toBe(expected);
   });
 
-  it("creates expressions attributes' names", () => {
-    expect.assertions(2);
-    const attribs = ['foo', '#foo'];
-    const expected = ['#na4d8', '#foo'];
-    attribs.forEach((attrib, i) => {
-      const result = getAttrName(attrib);
-      expect(result).toBe(expected[i]);
-    });
+  it.each([
+    ['new attribute', 'foo', '#na4d8'],
+    ['already encoded', '#foo', '#foo'],
+  ])('creates expressions attributes names - %s', (_, attrib, expected) => {
+    const result = getAttrName(attrib);
+    expect(result).toBe(expected);
   });
 
-  it("creates expressions attributes' values", () => {
-    expect.assertions(2);
-    const attribs = ['foo', ':foo'];
-    const expected = [':va4d8', ':foo'];
-    attribs.forEach((attrib, i) => {
-      const result = getAttrValue(attrib);
-      expect(result).toBe(expected[i]);
-    });
+  it.each([
+    ['new value', 'foo', ':va4d8'],
+    ['already encoded', ':foo', ':foo'],
+  ])('creates expressions attributes values - %s', (_, attrib, expected) => {
+    const result = getAttrValue(attrib);
+    expect(result).toBe(expected);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,12 @@
 import crypto from 'crypto';
 
 type ToStringFn = (data: unknown) => string;
-export const toString: ToStringFn = (data) =>
-  typeof data === 'object' ? JSON.stringify(data) : `${data}`;
+export const toString: ToStringFn = (data) => {
+  if (data instanceof Set) {
+    return `Set(${JSON.stringify(Array.from(data))}))`;
+  }
+  return typeof data === 'object' ? JSON.stringify(data) : `${data}`;
+};
 
 type Md5Fn = (data: unknown) => string;
 export const md5: Md5Fn = (data) => {


### PR DESCRIPTION
**Convert Sets to DynamoDbSet**
When a value is provided as a Set, it will be converted to a `DocumentClient.DynamoDbSet`

```
{
  Update: {
    Color: new Set(['Orange', 'Purple'])
  }
}
```

returns

```
{
  UpdateExpression: 'SET #n7295 = :v0a80',
  ExpressionAttributeNames: {
    '#n7295': 'Color',
  },
  ExpressionAttributeValues: {
    ':v0a80': docClient.createSet(['Orange', 'Purple']),
  },
}
```

**UpdateAdd and UpdateDelete**
this behavior will be automatic on `UpdateAdd` and `UpdateDelete` even if arrays are provided:

```
{
  UpdateAdd: {
    Color: ['Orange', 'Purple']
  }
}
```

returns

```
{
  UpdateExpression: 'ADD #n7295 :v0a80',
  ExpressionAttributeNames: {
    '#n7295': 'Color',
  },
  ExpressionAttributeValues: {
    ':v0a80': docClient.createSet(['Orange', 'Purple']),
  },
}
```
```
