### PR TITLE
refactor: reduce the size of bundled files by parcel-bundler

### DIFF
--- a/src/operations/single.test.ts
+++ b/src/operations/single.test.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 import type { DynoexprInput, DynoexprOutput } from '../dynoexpr';
 import {
@@ -7,7 +7,7 @@ import {
   convertValuesToDynamoDbSet,
 } from './single';
 
-const docClient = new AWS.DynamoDB.DocumentClient();
+const docClient = new DocumentClient();
 
 describe('single table operations', () => {
   it('applies consecutive expression getters to a parameters object', () => {

--- a/src/operations/single.ts
+++ b/src/operations/single.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 import type { DynoexprInput, DynamoDbValue, DynoexprOutput } from '../dynoexpr';
 import { getConditionExpression } from '../expressions/condition';
@@ -8,7 +8,7 @@ import { getUpdateExpression } from '../expressions/update';
 import { getUpdateOperationsExpression } from '../expressions/update-ops';
 import { getKeyConditionExpression } from '../expressions/key-condition';
 
-const docClient = new AWS.DynamoDB.DocumentClient();
+const docClient = new DocumentClient();
 
 type IsUpdateRemoveOnlyPresentFn = (params: DynoexprInput) => boolean;
 export const isUpdateRemoveOnlyPresent: IsUpdateRemoveOnlyPresentFn = (


### PR DESCRIPTION
Use `import { DocumentClient } from 'aws-sdk/clients/dynamodb'` instead of `import AWS from 'aws-sdk'`.

test command

```
sh -ex <<'__EOF__'
npm run build
rm -rf test-parcel
mkdir test-parcel
cd test-parcel
npm init --yes
npm install --save-dev parcel-bundler@1.12.4 typescript
npm install aws-sdk

cat <<'_EOF_' > index.ts
import { DocumentClient } from 'aws-sdk/clients/dynamodb';
import dynoexpr from '../dist';

new DocumentClient().put({
  TableName: 'table',
  Item: { id: 'id' },
  ...dynoexpr({ Condition: { id: 'attribute_not_exists' } }),
});
_EOF_

npx parcel build index.ts
__EOF__
```

Before
```
+ npx parcel build index.ts
✨  Built in 30.65s.

dist/index.js.map    ⚠️  12.42 MB     1.86s
dist/index.js         ⚠️  5.13 MB    28.71s
```

After
```
+ npx parcel build index.ts
✨  Built in 14.02s.

dist/index.js.map    ⚠️  4.02 MB     426ms
dist/index.js         871.37 KB    13.53s
```