### PR TITLE
feat: accept generic type to be applied to result

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ const params = dynoexpr({
 */
 ```
 
+**Type the resulting parameters**
+
+The resulting object is compatible with all `DocumentClient` requests, but if you want to be type-safe, `dynoexpr` accepts a generic type to be applied to the return value.
+
+```typescript
+const params = dynoexpr<AWS.DocumentClient.UpdateItemInput>({
+  TableName: 'Table',
+  Key: 1,
+  UpdateSet: { color: 'pink' },
+});
+```
+
 ## API
 
 ### dynoexpr&lt;T&gt;(params)

--- a/src/dynoexpr.d.ts
+++ b/src/dynoexpr.d.ts
@@ -31,7 +31,7 @@ type BatchWriteInput = {
   PutRequest?: unknown;
 };
 type BatchRequestItemsInput = Record<string, BatchGetInput | BatchWriteInput[]>;
-type BatchRequestInput = {
+export type BatchRequestInput = {
   RequestItems: BatchRequestItemsInput;
   [key: string]: unknown;
 };
@@ -43,7 +43,7 @@ type BatchRequestOutput = {
 // transact operations
 type TransactOperation = 'Get' | 'ConditionCheck' | 'Put' | 'Delete' | 'Update';
 type TransactRequestItems = Partial<Record<TransactOperation, DynoexprInput>>;
-type TransactRequestInput = {
+export type TransactRequestInput = {
   TransactItems: TransactRequestItems[];
   [key: string]: unknown;
 };
@@ -124,20 +124,16 @@ type UpdateOutput = Partial<{
   ExpressionAttributeValues: { [key: string]: DynamoDbValue };
 }>;
 
-type DynoexprInput = ConditionInput &
+export type DynoexprInput = ConditionInput &
   FilterInput &
   KeyConditionInput &
   ProjectionInput &
   UpdateInput &
   Record<string, unknown>;
 
-type DynoexprOutput = ConditionOutput &
+export type DynoexprOutput = ConditionOutput &
   FilterOutput &
   KeyConditionOutput &
   ProjectionOutput &
   UpdateOutput &
   Record<string, unknown>;
-
-export type DynoexprFn = (
-  params: DynoexprInput | BatchRequestInput | TransactRequestInput
-) => DynoexprOutput;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,35 @@
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
+
+import type { DynoexprOutput } from './dynoexpr';
+import dynoexpr from '.';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function assertType<T, U extends T>(): void {
+  expect.anything();
+}
+
+describe('high level API', () => {
+  it("doesn't require a type to be provided", () => {
+    expect.assertions(1);
+    const params = dynoexpr({
+      TableName: 'Table',
+      Key: 1,
+      UpdateSet: { color: 'pink' },
+    });
+
+    assertType<DynoexprOutput, typeof params>();
+    expect(params.TableName).toBe('Table');
+  });
+
+  it('accepts a type to be applied to the output', () => {
+    expect.assertions(1);
+    const params = dynoexpr<DocumentClient.UpdateItemInput>({
+      TableName: 'Table',
+      Key: 123,
+      UpdateSet: { color: 'pink' },
+    });
+
+    assertType<DocumentClient.ScanInput, typeof params>();
+    expect(params.Key).toBe(123);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-import type { DynoexprFn } from './dynoexpr';
+import type {
+  DynoexprInput,
+  BatchRequestInput,
+  TransactRequestInput,
+  DynoexprOutput,
+} from './dynoexpr';
 
 import { getSingleTableExpressions } from './operations/single';
 import { isBatchRequest, getBatchExpressions } from './operations/batch';
@@ -7,14 +12,16 @@ import {
   getTransactExpressions,
 } from './operations/transact';
 
-const dynoexpr: DynoexprFn = (params) => {
+type DynoexprParams = DynoexprInput | BatchRequestInput | TransactRequestInput;
+
+function dynoexpr<T = DynoexprOutput>(params: DynoexprParams): T {
   if (isBatchRequest(params)) {
-    return getBatchExpressions(params);
+    return (getBatchExpressions(params) as DynoexprOutput) as T;
   }
   if (isTransactRequest(params)) {
-    return getTransactExpressions(params);
+    return (getTransactExpressions(params) as DynoexprOutput) as T;
   }
-  return getSingleTableExpressions(params);
-};
+  return getSingleTableExpressions(params) as T;
+}
 
 export default dynoexpr;


### PR DESCRIPTION
this PR attempts to fix #16 

`dynoexpr` will accept an optional generic type to be applied to the output:

```typescript
const params = dynoexpr<DocumentClient.UpdateItemInput>({
  TableName: 'Table',
  Key: 123,
  UpdateSet: { color: 'pink' },
});
```