### PR TITLE
fix: update add attribute names

### DIFF
--- a/src/expressions/update-ops.test.ts
+++ b/src/expressions/update-ops.test.ts
@@ -89,8 +89,8 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         ':v51f2': 'bar',
         ':v862c': 2,
         ':v2362': { biz: 3 },
-        ':v5650': new Set([{ qux: 2 }]),
-        ':vc2b7': new Set([1, 2, 3]),
+        ':v77e7': new Set([{ qux: 2 }]),
+        ':v646d': new Set([1, 2, 3]),
       },
     };
     expect(result).toStrictEqual(expected);
@@ -122,8 +122,8 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         ':v2362': { biz: 3 },
         ':v51f2': 'bar',
         ':v862c': 2,
-        ':v5650': new Set([{ qux: 2 }]),
-        ':vc2b7': new Set([1, 2, 3]),
+        ':v77e7': new Set([{ qux: 2 }]),
+        ':v646d': new Set([1, 2, 3]),
       },
     };
     expect(result).toStrictEqual(expected);

--- a/src/expressions/update.test.ts
+++ b/src/expressions/update.test.ts
@@ -232,8 +232,8 @@ describe('update expression', () => {
         '#na4d8': 'foo',
       },
       ExpressionAttributeValues: {
-        ':v649c': new Set(['bar', 'baz']),
-        ':veb45': new Set([1, 2]),
+        ':v9ad1': new Set(['bar', 'baz']),
+        ':vd26b': new Set([1, 2]),
       },
     };
     expect(result).toStrictEqual(expected);
@@ -256,8 +256,8 @@ describe('update expression', () => {
         '#na4d8': 'foo',
       },
       ExpressionAttributeValues: {
-        ':v649c': new Set(['bar', 'baz']),
-        ':veb45': new Set([1, 2]),
+        ':v9ad1': new Set(['bar', 'baz']),
+        ':vd26b': new Set([1, 2]),
       },
     };
     expect(result).toStrictEqual(expected);

--- a/src/expressions/update.ts
+++ b/src/expressions/update.ts
@@ -36,10 +36,13 @@ export const getExpressionAttributes: GetExpressionAttributesFn = (params) => {
       const v = isMathExpression(key, value)
         ? parseOperationValue(value as string, key)
         : value;
-      acc.ExpressionAttributeValues[getAttrValue(v)] =
-        Array.isArray(v) && /ADD|DELETE/.test(UpdateAction)
-          ? new Set(v as string[])
-          : v;
+
+      if (Array.isArray(v) && /ADD|DELETE/.test(UpdateAction)) {
+        const s = new Set(v as string[]);
+        acc.ExpressionAttributeValues[getAttrValue(s)] = s;
+      } else {
+        acc.ExpressionAttributeValues[getAttrValue(v)] = v;
+      }
     }
     return acc;
   }, params as ExpressionAttributesMap);


### PR DESCRIPTION
Fixes: #24 

Attribute value labels were being inconsistently generated for sets on update add/remove