### PR TITLE
feat: allow multiple expressions on the same field

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ const results = await docClient
   .promise();
 ```
 
+**Using multiple expressions on the same field**
+
+You can hide multiple expressions on the same field, by packing them into an array and assigning it to the key with the field's name.
+
+```typescript
+const params = dynoexpr({
+  Condition: {
+    color: ['attribute_not_exists', 'yellow', 'blue'],
+  },
+  logicalOperator: 'OR',
+});
+
+/*
+ {
+  ConditionExpression: '(attribute_not_exists(#n9bfd)) \
+    OR (#n9bfd = :va351) \
+    OR (#n9bfd = :v0c8f)',
+  ExpressionAttributeNames: {
+    '#n9bfd': 'color'
+  },
+  ExpressionAttributeValues: {
+    ':va351': 'yellow',
+    ':v0c8f': 'blue'
+  }
+}
+*/
+```
+
 **Using functions**
 
 `DynamoDB` supports a number of [functions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions) to be evaluated when parsing expressions. You don't need to reference the `path` argument because that's identified by the object's key.

--- a/src/expressions/condition.test.ts
+++ b/src/expressions/condition.test.ts
@@ -16,6 +16,7 @@ describe('condition expression', () => {
     };
     const params: ConditionInput = { Condition };
     const result = getConditionExpression(params);
+
     const expected = {
       ConditionExpression: [
         '#n2661 = :va4d8',
@@ -66,6 +67,7 @@ describe('condition expression', () => {
     };
     const params: ConditionInput = { Condition };
     const result = getConditionExpression(params);
+
     const expected = {
       ConditionExpression: [
         'attribute_exists(#n2661)',
@@ -106,6 +108,7 @@ describe('condition expression', () => {
       ConditionLogicalOperator: 'OR',
     };
     const result = getConditionExpression(params);
+
     const expected = {
       ConditionExpression: [
         '#n2661 = :v849b',
@@ -137,6 +140,7 @@ describe('condition expression', () => {
     };
     const params: ConditionInput = { Condition };
     const result = getConditionExpression(params);
+
     const expected = {
       ConditionExpression: [
         'attribute_exists(#n2661)',
@@ -147,6 +151,30 @@ describe('condition expression', () => {
       ExpressionAttributeNames: {
         '#n2661': 'a',
         '#n578f': 'b',
+      },
+    };
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('builds a ConditionalExpression with multiple expressions on the same field', () => {
+    expect.assertions(1);
+    const Condition = {
+      key: ['attribute_not_exists', 'foobar'],
+    };
+    const params: ConditionInput = {
+      Condition,
+      ConditionLogicalOperator: 'OR',
+    };
+    const result = getConditionExpression(params);
+
+    const expected = {
+      ConditionExpression:
+        '(attribute_not_exists(#n531d)) OR (#n531d = :vc63f)',
+      ExpressionAttributeNames: {
+        '#n531d': 'key',
+      },
+      ExpressionAttributeValues: {
+        ':vc63f': 'foobar',
       },
     };
     expect(result).toStrictEqual(expected);

--- a/src/expressions/helpers.test.ts
+++ b/src/expressions/helpers.test.ts
@@ -178,6 +178,41 @@ describe('helpers for condition helpers', () => {
       expect(result).toStrictEqual(expected);
     });
 
+    it('builds a condition expression with a list of expressions for the same field', () => {
+      expect.assertions(1);
+      const result = buildConditionExpression({
+        Condition: {
+          a: [
+            'foo',
+            '> 1',
+            '>= 2',
+            '< 3',
+            '<= 4',
+            '<> 5',
+            'BETWEEN 6 AND 7',
+            'IN (foo, bar)',
+          ],
+          b: 'bar',
+        },
+        LogicalOperator: 'OR',
+      });
+
+      const expected = [
+        '#n2661 = :va4d8',
+        '#n2661 > :v849b',
+        '#n2661 >= :v862c',
+        '#n2661 < :vbaf3',
+        '#n2661 <= :v122c',
+        '#n2661 <> :v18d5',
+        '#n2661 between :vb2dc and :v2543',
+        '#n2661 in (:va4d8,:v51f2)',
+        '#n578f = :v51f2',
+      ]
+        .map((exp) => `(${exp})`)
+        .join(' OR ');
+      expect(result).toStrictEqual(expected);
+    });
+
     it('builds the ExpressionAttributeNameMap', () => {
       expect.assertions(1);
       const result = buildConditionAttributeNames(Condition);
@@ -234,6 +269,16 @@ describe('helpers for condition helpers', () => {
       const result = buildConditionAttributeValues(Condition2, params);
       const expected = {
         ':a': 'bar',
+        ':va4d8': 'foo',
+      };
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('builds the ExpressionAttributesValueMap with multiple expressions for the same field', () => {
+      expect.assertions(1);
+      const Condition2 = { b: ['foo', 'attribute_exists'] };
+      const result = buildConditionAttributeValues(Condition2);
+      const expected = {
         ':va4d8': 'foo',
       };
       expect(result).toStrictEqual(expected);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./",
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "es2017"],
+    "lib": ["es2015", "es2017", "es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
allows multiple expressions on the same field, by allowing arrays as values on the fields/values map.

```
const params = dynoexpr({
  Condition: {
    color: ['attribute_not_exists', 'yellow', 'blue'],
  },
  logicalOperator: 'OR',
});
```