### PR TITLE
fix: update types to include null

### DIFF
--- a/src/dynoexpr.d.ts
+++ b/src/dynoexpr.d.ts
@@ -11,7 +11,8 @@ type DynoexprInputValue =
   | Record<string, unknown>
   | Record<string, unknown>[]
   | Set<number>
-  | Set<string>;
+  | Set<string>
+  | null;
 
 type DynamoDbValue =
   | string
@@ -22,6 +23,7 @@ type DynamoDbValue =
   | boolean[]
   | Record<string, unknown>
   | Record<string, unknown>[]
+  | null
   | unknown;
 
 // batch operations

--- a/src/expressions/update-ops.test.ts
+++ b/src/expressions/update-ops.test.ts
@@ -18,17 +18,19 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         bez: [1, 2, 3],
         buz: { biz: 3 },
         boz: [{ qux: 2 }],
+        biz: null,
       },
     };
     const result = getUpdateSetExpression(params);
 
     const expected = {
       UpdateExpression:
-        'SET #na4d8 = #na4d8 - :v862c, #n51f2 = :v862c - #n51f2, #n6e88 = #n6e88 + :vad26, #n7aa0 = :vc2b7, #n66e7 = :v2362, #neeac = :v5650',
+        'SET #na4d8 = #na4d8 - :v862c, #n51f2 = :v862c - #n51f2, #n6e88 = #n6e88 + :vad26, #n7aa0 = :vc2b7, #n66e7 = :v2362, #neeac = :v5650, #n746d = :vf0bd',
       ExpressionAttributeNames: {
         '#na4d8': 'foo',
         '#n51f2': 'bar',
         '#n6e88': 'baz',
+        '#n746d': 'biz',
         '#n7aa0': 'bez',
         '#n66e7': 'buz',
         '#neeac': 'boz',
@@ -39,6 +41,7 @@ describe('update operations - SET/REMOVE/ADD/DELETE', () => {
         ':v2362': { biz: 3 },
         ':v5650': [{ qux: 2 }],
         ':vc2b7': [1, 2, 3],
+        ':vf0bd': null,
       },
     };
     expect(result).toStrictEqual(expected);

--- a/src/expressions/update.test.ts
+++ b/src/expressions/update.test.ts
@@ -26,6 +26,7 @@ describe('update expression', () => {
       fooBar: 'buzz',
       'foo.bar': 'quz',
       foo_bar: 'qiz',
+      FooBaz: null,
     };
     const params = { Update };
     const result = getExpressionAttributes(params);
@@ -39,6 +40,7 @@ describe('update expression', () => {
         '#n9cb1': 'foo-bar',
         '#n5dc0': 'fooBar',
         '#n5a6e': 'foo_bar',
+        '#nf26a': 'FooBaz',
       },
       ExpressionAttributeValues: {
         ':v51f2': 'bar',
@@ -46,6 +48,7 @@ describe('update expression', () => {
         ':v66e7': 'buz',
         ':vfef0': 'buzz',
         ':v11cd': 'quz',
+        ':vf0bd': null,
         ':vc4ab': 'qiz',
       },
     };
@@ -79,13 +82,14 @@ describe('update expression', () => {
         buz: { biz: 3 },
         'foo.bar': 4,
         'foo.bar.baz': 'buz',
+        'foo.baz': null,
       },
     };
     const result = getUpdateExpression(params);
 
     const expected = {
       UpdateExpression:
-        'SET #na4d8 = :v51f2, #n6e88 = :v862c, #n66e7 = :v2362, #na4d8.#n51f2 = :v122c, #na4d8.#n51f2.#n6e88 = :v66e7',
+        'SET #na4d8 = :v51f2, #n6e88 = :v862c, #n66e7 = :v2362, #na4d8.#n51f2 = :v122c, #na4d8.#n51f2.#n6e88 = :v66e7, #na4d8.#n6e88 = :vf0bd',
       ExpressionAttributeNames: {
         '#na4d8': 'foo',
         '#n51f2': 'bar',
@@ -98,6 +102,7 @@ describe('update expression', () => {
         ':v2362': { biz: 3 },
         ':v122c': 4,
         ':v66e7': 'buz',
+        ':vf0bd': null,
       },
     };
     expect(result).toStrictEqual(expected);
@@ -113,6 +118,7 @@ describe('update expression', () => {
     ['foo', 'Mon Jun 01 2020 20:54:50 GMT+0100 (British Summer Time)', false],
     ['foo', 'foo+bar@baz-buz.com', false],
     ['foo', 'http://baz-buz.com', false],
+    ['foo', null, false],
   ])(
     'identifies an expression as being a math expression',
     (expr1, expr2, expected) => {


### PR DESCRIPTION
This adds `null` to the two input types and adds some tests to demonstrate the functionality. Since `null` was already supported by the library, I marked it as a `fix`.

Fixes #31