### PR TITLE
feat(deps)!: make aws-sdk a peer/dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,13 @@
 		]
 	},
 	"types": "dist/index.d.ts",
-	"dependencies": {
-		"aws-sdk": "^2.2.0"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@types/jest": "28.1.4",
 		"@types/node": "18.0.0",
 		"@typescript-eslint/eslint-plugin": "5.30.3",
 		"@typescript-eslint/parser": "5.30.3",
+		"aws-sdk": "^2.2.0",
 		"esbuild": "0.14.48",
 		"eslint": "8.19.0",
 		"eslint-config-airbnb-base": "15.0.0",
@@ -56,6 +55,9 @@
 		"prettier": "2.7.1",
 		"ts-jest": "28.0.5",
 		"typescript": "4.7.4"
+	},
+	"peerDependencies": {
+		"aws-sdk": "^2.2.0"
 	},
 	"scripts": {
 		"build": "bash sh/build.sh",


### PR DESCRIPTION
This partially addresses the problem raised in issue #29. It allows for consumers to reliably load only their own AWS SDK version rather than risking potentially bundling multiple copies in a build. It also makes this package more Lambda function friendly, since the aws-sdk version is vended by the runtime by default and does not need to be packaged in.

Note that this change does not make this package agnostic to the choice between AWS SDK v2 and v3. The current implementation still relies on imports that exist on v2 but not v3.