### PR TITLE
feat: avoid instantiating DocumentClient

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,4 @@
-import AWS from 'aws-sdk';
-
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import type { DynoexprOutput } from './dynoexpr';
 import dynoexpr from '.';
 
@@ -23,13 +22,13 @@ describe('high level API', () => {
 
 	it('accepts a type to be applied to the output', () => {
 		expect.assertions(1);
-		const params = dynoexpr<AWS.DynamoDB.DocumentClient.UpdateItemInput>({
+		const params = dynoexpr<DocumentClient.UpdateItemInput>({
 			TableName: 'Table',
 			Key: 123,
 			UpdateSet: { color: 'pink' },
 		});
 
-		assertType<AWS.DynamoDB.DocumentClient.ScanInput, typeof params>();
+		assertType<DocumentClient.ScanInput, typeof params>();
 		expect(params.Key).toBe(123);
 	});
 });

--- a/src/operations/single.ts
+++ b/src/operations/single.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 import type { DynoexprInput, DynamoDbValue, DynoexprOutput } from '../dynoexpr';
 import { getConditionExpression } from '../expressions/condition';
@@ -10,7 +10,8 @@ import { getKeyConditionExpression } from '../expressions/key-condition';
 
 import { trimEmptyExpressionAttributes } from './helpers';
 
-const docClient = new AWS.DynamoDB.DocumentClient();
+export const createDynamoDbSet =
+	DocumentClient.prototype.createSet.bind(undefined);
 
 type ConvertValuesToDynamoDbSetFn = (
 	attributeValues: Record<string, unknown>
@@ -20,7 +21,7 @@ export const convertValuesToDynamoDbSet: ConvertValuesToDynamoDbSetFn = (
 ) =>
 	Object.entries(attributeValues).reduce((acc, [key, value]) => {
 		if (value instanceof Set) {
-			acc[key] = docClient.createSet(Array.from(value));
+			acc[key] = createDynamoDbSet(Array.from(value));
 		} else {
 			acc[key] = value as DynamoDbValue;
 		}


### PR DESCRIPTION
This refactor avoids instantiating a DynamoDB.DocumentClient object (which in turn would instantiate an underlying DynamoDB service client) by accessing the `createSet` method from the prototype directly.

The interface for `createSet` is:

```typescript
createSet(
  list: number[]|string[]|DocumentClient.binaryType[], 
  options?: DocumentClient.CreateSetOptions
): DocumentClient.DynamoDbSet;
```

And the implementation is:

```typescript
createSet: function(list, options) {
  options = options || {};
  return new DynamoDBSet(list, options);
}
```

As we can see, there is no reliance on the `this` instance, so calling the method from the prototype with an undefined `this` value should work fine. It would have perhaps been preferred to utilize the `DynamoDBSet` class directly, but that is marked with `@private` annotations within the AWS SDK while the `createSet` method on DocumentClient is part of the public API.

Aside from the removal of client instantiation, this change also scopes imports to just the DynamoDB specific resources. This has been measured to improve performance by several milliseconds in Lambda runtimes.

This somewhat relates to issue #29, but it doesn't really address it.